### PR TITLE
chore: release v0.1.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2791,7 +2791,7 @@ dependencies = [
 
 [[package]]
 name = "pharia-skill-cli"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pharia-skill-cli"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2021"
 repository = "https://github.com/Aleph-Alpha/pharia-skill-cli"
 


### PR DESCRIPTION
## 🤖 New release
* `pharia-skill-cli`: 0.1.7 -> 0.1.8

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.0]

### Features

- Allow setting using pooling allocation from env - ([a9127cf](https://github.com/Aleph-Alpha/pharia-skill-cli/commit/a9127cfaef715df1f39f15ca13e35475849f9c49))
- Remove csi shell on different port - ([70659fb](https://github.com/Aleph-Alpha/pharia-skill-cli/commit/70659fb5cbd13cafb13cbf15f10f96576120ab69))
- Add fallback for log level when processing app config - ([bdedd72](https://github.com/Aleph-Alpha/pharia-skill-cli/commit/bdedd72e3a440a5bfd55c2803a907cd159889b6c))
- Allow configuring update interval for polling namespace configurations - ([87cc1f5](https://github.com/Aleph-Alpha/pharia-skill-cli/commit/87cc1f59450c2f7524a47dfd7b42287a4a203ea5))
- Kernel no longer needs API TOKEN to boot up - ([5aeb040](https://github.com/Aleph-Alpha/pharia-skill-cli/commit/5aeb040ce26310ae446734a2bd96e97166d63f99))
- Remove default tag - ([65c7940](https://github.com/Aleph-Alpha/pharia-skill-cli/commit/65c7940c7dc483f784f2cc277aeaa75c857e2f76))
- Shell wait for all config has been loaded once - ([b05c91a](https://github.com/Aleph-Alpha/pharia-skill-cli/commit/b05c91a5ad73b6c030799dfdfe622b13fc6bbc21))
- Add pharia-skill run subcommand - ([fbaf12b](https://github.com/Aleph-Alpha/pharia-skill-cli/commit/fbaf12b1e5f4cf97a99aa53ac8e721b5eaa70a0b))
- Add publish skill sub-command - ([baab66f](https://github.com/Aleph-Alpha/pharia-skill-cli/commit/baab66fe66e834248d391278c1f8a36dd0d1f617))
- Introduce pharia skill cli - ([a485cd9](https://github.com/Aleph-Alpha/pharia-skill-cli/commit/a485cd9484a845e84baccaa00c618d4233885415))

### Fixes

- CONFIG_UPDATE_INTERVAL is now NAMESPACE_UPDATE_INTERVAL and it is parsed correctly - ([b718b0d](https://github.com/Aleph-Alpha/pharia-skill-cli/commit/b718b0d146ac53186a4dc66c2abf631f88aceef9))
- Inspect skills in namespace config - ([60c7def](https://github.com/Aleph-Alpha/pharia-skill-cli/commit/60c7def9d2a4d77ca6113a3eb478a02c2d06abdf))

### Documentation

- Add instruction for logging in to JFrog registry - ([ef9ba2c](https://github.com/Aleph-Alpha/pharia-skill-cli/commit/ef9ba2c28742c3c04ff540c5ba403bca8157266f))
- Update Skill repository - ([b4c7f92](https://github.com/Aleph-Alpha/pharia-skill-cli/commit/b4c7f92bd9a6b2955ac8e92f560afb40c9032577))

### Builds

- Fix out of sync lock-file - ([04a7329](https://github.com/Aleph-Alpha/pharia-skill-cli/commit/04a732928d7bce97ba8076a05b825c3efe32d66c))
- Update package manifest - ([6f23f0a](https://github.com/Aleph-Alpha/pharia-skill-cli/commit/6f23f0a1062b717f0065c5586694378890749a65))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).