### PR TITLE
chore: release v0.1.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.17](https://github.com/Aleph-Alpha/pharia-skill-cli/compare/v0.1.16...v0.1.17)
+
+### Builds
+
+- *(deps)* Bump thiserror from 1.0.68 to 1.0.69 - ([b4df9ea](https://github.com/Aleph-Alpha/pharia-skill-cli/commit/b4df9ea19188203241876b1dde2061d06b0853b2))
+- *(deps)* Bump the minor group with 82 updates - ([9f6ad63](https://github.com/Aleph-Alpha/pharia-skill-cli/commit/9f6ad636a710fb7c2046c7faeb60f28f502cbee4))
+
+
 ## [0.1.0]
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,7 +54,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
  "tokenizers",
 ]
 
@@ -2551,7 +2551,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
  "tokio",
  "tracing",
  "unicase",
@@ -2684,7 +2684,7 @@ dependencies = [
  "js-sys",
  "once_cell",
  "pin-project-lite",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2700,7 +2700,7 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
  "tokio",
  "tonic",
  "tracing",
@@ -2740,7 +2740,7 @@ dependencies = [
  "percent-encoding",
  "rand",
  "serde_json",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -2810,7 +2810,7 @@ dependencies = [
 
 [[package]]
 name = "pharia-skill-cli"
-version = "0.1.16"
+version = "0.1.17"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -3105,7 +3105,7 @@ dependencies = [
  "rand_chacha",
  "simd_helpers",
  "system-deps",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
  "v_frame",
  "wasm-bindgen",
 ]
@@ -3164,7 +3164,7 @@ checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
  "getrandom",
  "libredox",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3819,7 +3819,7 @@ dependencies = [
  "once_cell",
  "regex",
  "strum 0.26.3",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
  "tokenizers",
  "unicode-segmentation",
 ]
@@ -3830,7 +3830,7 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl 1.0.68",
+ "thiserror-impl 1.0.69",
 ]
 
 [[package]]
@@ -3944,7 +3944,7 @@ dependencies = [
  "serde",
  "serde_json",
  "spm_precompiled",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
  "unicode-normalization-alignments",
  "unicode-segmentation",
  "unicode_categories",
@@ -4744,7 +4744,7 @@ dependencies = [
  "object",
  "smallvec",
  "target-lexicon",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
  "wasmparser 0.218.0",
  "wasmtime-environ",
  "wasmtime-versioned-export-macros",
@@ -4855,7 +4855,7 @@ dependencies = [
  "once_cell",
  "rustix",
  "system-interface",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
  "tokio",
  "tracing",
  "url",
@@ -4959,7 +4959,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "bitflags 2.6.0",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
  "tracing",
  "wasmtime",
  "wiggle-macro",
@@ -5261,7 +5261,7 @@ checksum = "e366f27a5cabcddb2706a78296a40b8fcc451e1a6aba2fc1d94b4a01bdaaef4b"
 dependencies = [
  "anyhow",
  "log",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
  "wast 35.0.2",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pharia-skill-cli"
-version = "0.1.16"
+version = "0.1.17"
 edition = "2021"
 repository = "https://github.com/Aleph-Alpha/pharia-skill-cli"
 


### PR DESCRIPTION
## 🤖 New release
* `pharia-skill-cli`: 0.1.16 -> 0.1.17

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.17](https://github.com/Aleph-Alpha/pharia-skill-cli/compare/v0.1.16...v0.1.17)

### Builds

- *(deps)* Bump thiserror from 1.0.68 to 1.0.69 - ([b4df9ea](https://github.com/Aleph-Alpha/pharia-skill-cli/commit/b4df9ea19188203241876b1dde2061d06b0853b2))
- *(deps)* Bump the minor group with 82 updates - ([9f6ad63](https://github.com/Aleph-Alpha/pharia-skill-cli/commit/9f6ad636a710fb7c2046c7faeb60f28f502cbee4))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).