### PR TITLE
chore: release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/Aleph-Alpha/pharia-skill-cli/compare/v0.3.6...v0.4.0)
+
+### Features
+
+- [**breaking**] Remove run command, JFrog registry and simplify dependencies - ([eb805e6](https://github.com/Aleph-Alpha/pharia-skill-cli/commit/eb805e639ea9725a1120210d2087fd9f54141f47))
+
+### Documentation
+
+- Update readme - ([b508c6c](https://github.com/Aleph-Alpha/pharia-skill-cli/commit/b508c6c7e3bddf30db3257b1d3f09ad4fc4d350f))
+
+
 ## [0.3.3](https://github.com/Aleph-Alpha/pharia-skill-cli/compare/v0.3.2...v0.3.3)
 
 ### Builds

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1192,7 +1192,7 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pharia-skill-cli"
-version = "0.3.6"
+version = "0.4.0"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pharia-skill-cli"
-version = "0.3.6"
+version = "0.4.0"
 edition = "2021"
 repository = "https://github.com/Aleph-Alpha/pharia-skill-cli"
 


### PR DESCRIPTION



## 🤖 New release

* `pharia-skill-cli`: 0.3.6 -> 0.4.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.0](https://github.com/Aleph-Alpha/pharia-skill-cli/compare/v0.3.6...v0.4.0)

### Features

- [**breaking**] Remove run command, JFrog registry and simplify dependencies - ([eb805e6](https://github.com/Aleph-Alpha/pharia-skill-cli/commit/eb805e639ea9725a1120210d2087fd9f54141f47))

### Documentation

- Update readme - ([b508c6c](https://github.com/Aleph-Alpha/pharia-skill-cli/commit/b508c6c7e3bddf30db3257b1d3f09ad4fc4d350f))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).