### PR TITLE
chore: release v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1](https://github.com/Aleph-Alpha/pharia-skill-cli/compare/v0.4.0...v0.4.1)
+
+### Documentation
+
+- Add usage docs - ([63a444c](https://github.com/Aleph-Alpha/pharia-skill-cli/commit/63a444c4d176a7df37c85e0440edf3d71a30edb9))
+
+
 ## [0.4.0](https://github.com/Aleph-Alpha/pharia-skill-cli/compare/v0.3.6...v0.4.0)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1192,7 +1192,7 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pharia-skill-cli"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pharia-skill-cli"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 repository = "https://github.com/Aleph-Alpha/pharia-skill-cli"
 


### PR DESCRIPTION



## 🤖 New release

* `pharia-skill-cli`: 0.4.0 -> 0.4.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.1](https://github.com/Aleph-Alpha/pharia-skill-cli/compare/v0.4.0...v0.4.1)

### Documentation

- Add usage docs - ([63a444c](https://github.com/Aleph-Alpha/pharia-skill-cli/commit/63a444c4d176a7df37c85e0440edf3d71a30edb9))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).