### PR TITLE
chore: release v0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.3](https://github.com/Aleph-Alpha/pharia-skill-cli/compare/v0.4.2...v0.4.3)
+
+### Fixes
+
+- Fix clippy lints - ([67b1df3](https://github.com/Aleph-Alpha/pharia-skill-cli/commit/67b1df3bad626f84af86d450e9fb17fe9c634fdd))
+
+
 ## [0.4.2](https://github.com/Aleph-Alpha/pharia-skill-cli/compare/v0.4.1...v0.4.2)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1192,7 +1192,7 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pharia-skill-cli"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pharia-skill-cli"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2024"
 repository = "https://github.com/Aleph-Alpha/pharia-skill-cli"
 description = "A simple CLI that helps you publish skills on Pharia Kernel."


### PR DESCRIPTION



## 🤖 New release

* `pharia-skill-cli`: 0.4.2 -> 0.4.3

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.3](https://github.com/Aleph-Alpha/pharia-skill-cli/compare/v0.4.2...v0.4.3)

### Fixes

- Fix clippy lints - ([67b1df3](https://github.com/Aleph-Alpha/pharia-skill-cli/commit/67b1df3bad626f84af86d450e9fb17fe9c634fdd))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).