### PR TITLE
chore: release v0.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.4](https://github.com/Aleph-Alpha/pharia-skill-cli/compare/v0.4.3...v0.4.4)
+
+### Fixes
+
+- Don't use duplicate ssl libraries - ([9e29db0](https://github.com/Aleph-Alpha/pharia-skill-cli/commit/9e29db0fddd73b28e4932678d918fe052c6969ca))
+
+### Builds
+
+- *(deps)* Bump the minor group with 2 updates - ([c46ba33](https://github.com/Aleph-Alpha/pharia-skill-cli/commit/c46ba33f76764536da4e9828e41d120ac31ed294))
+- *(deps)* Bump dtolnay/rust-toolchain - ([8f0e9d1](https://github.com/Aleph-Alpha/pharia-skill-cli/commit/8f0e9d1c34bd21754ef51604ca7769582141072a))
+
+
 ## [0.4.3](https://github.com/Aleph-Alpha/pharia-skill-cli/compare/v0.4.2...v0.4.3)
 
 ### Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1068,7 +1068,7 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pharia-skill-cli"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pharia-skill-cli"
-version = "0.4.3"
+version = "0.4.4"
 edition = "2024"
 repository = "https://github.com/Aleph-Alpha/pharia-skill-cli"
 description = "A simple CLI that helps you publish skills on Pharia Kernel."


### PR DESCRIPTION



## 🤖 New release

* `pharia-skill-cli`: 0.4.3 -> 0.4.4

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.4](https://github.com/Aleph-Alpha/pharia-skill-cli/compare/v0.4.3...v0.4.4)

### Fixes

- Don't use duplicate ssl libraries - ([9e29db0](https://github.com/Aleph-Alpha/pharia-skill-cli/commit/9e29db0fddd73b28e4932678d918fe052c6969ca))

### Builds

- *(deps)* Bump the minor group with 2 updates - ([c46ba33](https://github.com/Aleph-Alpha/pharia-skill-cli/commit/c46ba33f76764536da4e9828e41d120ac31ed294))
- *(deps)* Bump dtolnay/rust-toolchain - ([8f0e9d1](https://github.com/Aleph-Alpha/pharia-skill-cli/commit/8f0e9d1c34bd21754ef51604ca7769582141072a))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).