### PR TITLE
chore: release v0.4.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.6](https://github.com/Aleph-Alpha/pharia-skill-cli/compare/v0.4.5...v0.4.6)
+
+### Builds
+
+- *(deps)* Bump libc from 0.2.171 to 0.2.172 in the minor group - ([87dcc98](https://github.com/Aleph-Alpha/pharia-skill-cli/commit/87dcc98850ea088e8c6644322c2a28fcc24e50bb))
+- *(deps)* Bump release-plz/action from 0.5.103 to 0.5.104 - ([71abeda](https://github.com/Aleph-Alpha/pharia-skill-cli/commit/71abeda3da09deadae97010b4dae444ebe45f6f8))
+- *(deps)* Bump the minor group with 3 updates - ([1852f6d](https://github.com/Aleph-Alpha/pharia-skill-cli/commit/1852f6d425e86f454c3367b195e1c31fc6673e6a))
+- *(deps)* Bump cc from 1.2.18 to 1.2.19 in the minor group - ([f1c499e](https://github.com/Aleph-Alpha/pharia-skill-cli/commit/f1c499ea0ce59c73ba32054d9a939db1d3faab6e))
+- *(deps)* Bump release-plz/action from 0.5.102 to 0.5.103 - ([7137853](https://github.com/Aleph-Alpha/pharia-skill-cli/commit/7137853cbfc1acb9495e0cd64775c1fd831545de))
+- *(deps)* Bump rustls from 0.23.25 to 0.23.26 in the minor group - ([2d207bf](https://github.com/Aleph-Alpha/pharia-skill-cli/commit/2d207bf5949acf98b50f261ee9d6bcb3de7984ca))
+- *(deps)* Bump the minor group with 2 updates - ([f21b3b2](https://github.com/Aleph-Alpha/pharia-skill-cli/commit/f21b3b263957f976fca62958009709efe30be9fe))
+- *(deps)* Bump release-plz/action from 0.5.101 to 0.5.102 - ([50858a5](https://github.com/Aleph-Alpha/pharia-skill-cli/commit/50858a50cff073a53146a67133652bffed387436))
+
+
 ## [0.4.5](https://github.com/Aleph-Alpha/pharia-skill-cli/compare/v0.4.4...v0.4.5)
 
 ### Builds

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1069,7 +1069,7 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pharia-skill-cli"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pharia-skill-cli"
-version = "0.4.5"
+version = "0.4.6"
 edition = "2024"
 repository = "https://github.com/Aleph-Alpha/pharia-skill-cli"
 description = "A simple CLI that helps you publish skills on Pharia Kernel."


### PR DESCRIPTION



## 🤖 New release

* `pharia-skill-cli`: 0.4.5 -> 0.4.6

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.6](https://github.com/Aleph-Alpha/pharia-skill-cli/compare/v0.4.5...v0.4.6)

### Builds

- *(deps)* Bump libc from 0.2.171 to 0.2.172 in the minor group - ([87dcc98](https://github.com/Aleph-Alpha/pharia-skill-cli/commit/87dcc98850ea088e8c6644322c2a28fcc24e50bb))
- *(deps)* Bump release-plz/action from 0.5.103 to 0.5.104 - ([71abeda](https://github.com/Aleph-Alpha/pharia-skill-cli/commit/71abeda3da09deadae97010b4dae444ebe45f6f8))
- *(deps)* Bump the minor group with 3 updates - ([1852f6d](https://github.com/Aleph-Alpha/pharia-skill-cli/commit/1852f6d425e86f454c3367b195e1c31fc6673e6a))
- *(deps)* Bump cc from 1.2.18 to 1.2.19 in the minor group - ([f1c499e](https://github.com/Aleph-Alpha/pharia-skill-cli/commit/f1c499ea0ce59c73ba32054d9a939db1d3faab6e))
- *(deps)* Bump release-plz/action from 0.5.102 to 0.5.103 - ([7137853](https://github.com/Aleph-Alpha/pharia-skill-cli/commit/7137853cbfc1acb9495e0cd64775c1fd831545de))
- *(deps)* Bump rustls from 0.23.25 to 0.23.26 in the minor group - ([2d207bf](https://github.com/Aleph-Alpha/pharia-skill-cli/commit/2d207bf5949acf98b50f261ee9d6bcb3de7984ca))
- *(deps)* Bump the minor group with 2 updates - ([f21b3b2](https://github.com/Aleph-Alpha/pharia-skill-cli/commit/f21b3b263957f976fca62958009709efe30be9fe))
- *(deps)* Bump release-plz/action from 0.5.101 to 0.5.102 - ([50858a5](https://github.com/Aleph-Alpha/pharia-skill-cli/commit/50858a50cff073a53146a67133652bffed387436))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).